### PR TITLE
Added compilation flags to force C++11 standard

### DIFF
--- a/build_analyzer.py
+++ b/build_analyzer.py
@@ -43,8 +43,8 @@ include_paths = [ "./AnalyzerSDK/include" ]
 link_paths = [ "./AnalyzerSDK/lib" ]
 link_dependencies = [ "-lAnalyzer" ] #refers to libAnalyzer.dylib or libAnalyzer.so
 
-debug_compile_flags = "-O0 -w -c -fpic -g"
-release_compile_flags = "-O3 -w -c -fpic"
+debug_compile_flags = "-O0 -w -c -fpic -g -std=c++11"
+release_compile_flags = "-O3 -w -c -fpic -std=c++11"
 
 def run_command(cmd):
     "Display cmd, then run it in a subshell, raise if there's an error"


### PR DESCRIPTION
This change prevents from compilation errors when your build environment uses newer C++ standard:
```
source/GameCubeControllerSimulationDataGenerator.cpp:153:14: error: expression is not an integral constant expression
        case GamecubeGenerationState::IdCmd:
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

My setup:
```
➜ g++ --version
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
Apple clang version 12.0.5 (clang-1205.0.22.11)
Target: x86_64-apple-darwin20.6.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```